### PR TITLE
Add custom.git_status overide using spaceship-prompt implementation.

### DIFF
--- a/bin/git_status_prompt.zsh
+++ b/bin/git_status_prompt.zsh
@@ -1,0 +1,97 @@
+#!/usr/bin/env zsh
+
+# integrating with the same basic functionality as https://starship.rs/config/#git-status
+#
+# From https://github.com/starship/starship/blob/v0.45.2/src/modules/git_status.rs#L13-L26
+#
+# $conflicted$stashed$deleted$renamed$modified$staged$untracked$ahead_behind
+# 
+# $ahead_behind => Displays diverged ahead or behind format string based on the current status of the repo
+#
+# The following symbols will be used to represent the repo's status:
+#   `=` – This branch has merge conflicts
+#   `⇡` – This branch is ahead of the branch being tracked
+#   `⇣` – This branch is behind of the branch being tracked
+#   `⇕` – This branch has diverged from the branch being tracked
+#   `?` — There are untracked files in the working directory
+#   `$` — A stash exists for the local repository
+#   `!` — There are file modifications in the working directory
+#   `+` — A new file has been added to the staging area
+#   `»` — A renamed file has been added to the staging area
+#   `✘` — A file's deletion has been added to the staging area
+#
+function gitstatus_prompt_update() {
+  local INDEX git_status=""
+
+  # This logic is largely inspired by: https://github.com/denysdovhan/spaceship-prompt/blob/v3.11.2/sections/git_status.zsh
+  INDEX=$(command git status --porcelain -b 2> /dev/null)
+
+  # Check for unmerged files
+  if $(echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null); then
+    git_status+="="
+  elif $(echo "$INDEX" | command grep '^AA ' &> /dev/null); then
+    git_status+="="
+  elif $(echo "$INDEX" | command grep '^DD ' &> /dev/null); then
+    git_status+="="
+  elif $(echo "$INDEX" | command grep '^[DA]U ' &> /dev/null); then
+    git_status+="+"
+  fi
+
+  # Check for stashes
+  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+    git_status+="$"
+  fi
+
+  # Check for deleted files
+  if $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
+    # staged deleted
+    git_status+="✘"
+  fi
+
+  # Check for renamed files
+  if $(echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null); then
+    git_status+="»"
+  fi
+
+  # Check for modified files
+  if $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+    git_status+="!"
+  fi
+
+  # Check for untracked files
+  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
+  fi
+
+  # Check for staged files
+  if $(echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null); then
+    git_status+="+"
+  elif $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
+    git_status+="+"
+  elif $(echo "$INDEX" | command grep '^UA' &> /dev/null); then
+    git_status+="+"
+  fi
+
+  # Check whether branch is ahead
+  local is_ahead=false
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
+    is_ahead=true
+  fi
+
+  # Check whether branch is behind
+  local is_behind=false
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
+    is_behind=true
+  fi
+
+  # Check wheather branch has diverged
+  if [[ "$is_ahead" == true && "$is_behind" == true ]]; then
+    git_status+="⇕"
+  else
+    [[ "$is_ahead" == true ]] && git_status+="⇡"
+    [[ "$is_behind" == true ]] && git_status="⇣"
+  fi
+
+  echo -n "$git_status"
+}
+gitstatus_prompt_update

--- a/install
+++ b/install
@@ -69,6 +69,10 @@ copy-dotfile() {
 }
 
 link-dotfile "starship/starship.toml" "$HOME/.config/starship.toml"
+
+mkdir -p ~/bin
+link-dotfile "bin/git_status_prompt.zsh" "$HOME/bin/git_status_prompt.zsh"
+
 link-dotfile "zsh/zshenv" "$HOME/.zshenv"
 link-dotfile "zsh/zprofile" "$HOME/.zprofile"
 link-dotfile "zsh/zshrc" "$HOME/.zshrc"

--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -8,6 +8,7 @@ $git_branch\
 $git_commit\
 $git_state\
 $git_status\
+${custom.git_status}\
 $hg_branch\
 $docker_context\
 $package\
@@ -52,6 +53,15 @@ $character"""
 [git_status]
 # way too slow
 disabled = true
+
+[custom.git_status]
+description = "git status which calls git directly"
+command = "~/bin/git_status_prompt.zsh || true"
+directories = []
+when = "true"
+style = "bold red"
+format = "[\\[$output\\]]($style) "
+disabled = false
 
 [[battery.display]]  # "bold red" style when capacity is between 0% and 10%
 threshold = 10


### PR DESCRIPTION
Since the default libgit2 integration in starship is so slow (for larger repos I commonly work in, its > 8s) the default `$git_status` prompt has been disabled for quite some time.

This brings back a customized version of leveraging both starship@0.45's new custom prompts (lets you run arbitrary shell commands) and [denysdovhan/spaceship-prompt](https://github.com/denysdovhan/spaceship-prompt) git status module to provide a much faster implementation (by using `git status` natively).

In smaller repos, this is a bit slower than the built in starship implementation (from 0.023s to 0.084s) but on larger repos it is **massively** faster (from 8.654s to 0.509s).