### PR TITLE
feat: Update to using setup-local-dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 zsh/dist/
 shells/dist/
 binutils/config/local.config.lua
+binutils/local-crates
 local-dotfiles/
 wezterm/local_config_overrides.lua
 !.lazy.lua

--- a/binutils/config/config.lua
+++ b/binutils/config/config.lua
@@ -3,7 +3,7 @@ local utils = require("utils")
 ---@type Config
 return {
   crate_locations = {
-    "~/src/rwjblue/dotfiles/binutils/crates/",
+    "~/src/rwjblue/dotfiles/binutils/",
     "~/src/malleatus/shared_binutils"
   },
   shell_caching = {

--- a/binutils/local-crates
+++ b/binutils/local-crates
@@ -1,1 +1,0 @@
-../local-dotfiles/crates/

--- a/utils/build-binutils.zsh
+++ b/utils/build-binutils.zsh
@@ -14,11 +14,10 @@ fi
 echo "Building malleatus/shared_binutils"
 (cd "$HOME/src/malleatus/shared_binutils/" && cargo build)
 
-# Create local-dotfiles directory if it doesn't exist
-if [ ! -d "$DOTFILES/local-dotfiles/crates" ]; then
-  echo "Creating local-dotfiles directory"
-  mkdir -p "$DOTFILES/local-dotfiles/crates/"
-fi
+
+"$HOME/src/malleatus/shared_binutils/target/debug/setup-local-dotfiles" \
+  --local-dotfiles-path ~/src/workstuff/local-dotfiles \
+  --local-crates-target-path ~/src/rwjblue/dotfiles/binutils/local-crates
 
 echo "Building binutils"
 (cd "$DOTFILES/binutils" && cargo build)


### PR DESCRIPTION
* Update `crate_locations` to point to `binutils/` instead of `binutils/crates/` (it processes the workspace root properly to detect all of the crates referenced by `*crates/*` in workspace members)
* Add `binutils/local-crates` to `.gitignore`
* Remove symlink to `local-dotfiles/crates/` (shouldn't be checked in)
* Use `setup-local-dotfiles` binary to manage local crates setup

This change simplifies the local crates setup by using the dedicated tool from shared_binutils instead of manual directory creation and symlinks.

See https://github.com/malleatus/shared_binutils/pull/84