### PR TITLE
feat(mise): Use `mise` for managing node versions if `volta` is missing

### DIFF
--- a/packages/zsh/zshrc
+++ b/packages/zsh/zshrc
@@ -172,7 +172,14 @@ alias gc='g commit --verbose' # use verbose mode with $EDITOR
 
 alias gah='g commit --amend -CHEAD' # amend the previous commit without prompting for message
 
-_ensure_first_path "$VOLTA_HOME/bin"
+if command -v volta >/dev/null 2>&1; then
+  # Configure Volta environment
+  export VOLTA_HOME="$HOME/.volta"
+
+  # Ensure Volta's bin directory is first in the PATH (if volta is present, it "should win")
+  _ensure_first_path "$VOLTA_HOME/bin"
+fi
+
 _ensure_first_path "/opt/homebrew/opt/fzf/bin"
 _ensure_first_path "$HOME/src/rwjblue/dotfiles/binutils/crates/global/target/debug"
 _ensure_first_path "$HOME/src/malleatus/shared_binutils/global/target/debug"

--- a/taskfiles/system.yml
+++ b/taskfiles/system.yml
@@ -24,20 +24,10 @@ tasks:
   install:requirements:
     internal: true
     cmds:
-      - task: install:volta
       - task: install:rust
       - task: install:platform_tools
       - task: install:cargo_tools
       - task: mise:install
-
-  install:volta:
-    internal: true
-    status:
-      - which volta
-    cmds:
-      - curl https://get.volta.sh | bash
-      - $HOME/.volta/volta install node
-      - $HOME/.volta/volta install yarn
 
   install:rust:
     internal: true


### PR DESCRIPTION
Work machines still use `volta` by default (it's preinstalled), but for my personal machine just use `mise` for managing `node`.