### PR TITLE
Add tests for debug-path helpers

### DIFF
--- a/packages/binutils/crates/global/src/bin/debug-path.rs
+++ b/packages/binutils/crates/global/src/bin/debug-path.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use tree_sitter::{Node, Parser as TSParser, Query, QueryCursor};
+use crate::debug_path_helpers::{get_line_content, get_line_number};
 
 /// A tool to debug and inspect the $PATH environment variable.
 #[derive(Parser)]
@@ -154,25 +155,4 @@ fn process_shell_file(path: &Path) -> Result<()> {
     }
 
     Ok(())
-}
-// Helper function to get the line number from byte offset
-fn get_line_number(line_offsets: &[(usize, &str)], byte_offset: usize) -> usize {
-    match line_offsets.binary_search_by(|&(offset, _)| offset.cmp(&byte_offset)) {
-        Ok(index) => index,
-        Err(index) => index,
-    }
-}
-
-// Helper function to get the line content where the node is located
-fn get_line_content<'a>(source_code: &'a str, node: Node) -> &'a str {
-    let start = source_code[..node.start_byte()]
-        .rfind('\n')
-        .map(|pos| pos + 1)
-        .unwrap_or(0);
-    let end = source_code[node.end_byte()..]
-        .find('\n')
-        .map(|pos| node.end_byte() + pos)
-        .unwrap_or(source_code.len());
-
-    &source_code[start..end]
 }

--- a/packages/binutils/crates/global/src/debug_path_helpers.rs
+++ b/packages/binutils/crates/global/src/debug_path_helpers.rs
@@ -1,0 +1,58 @@
+use tree_sitter::Node;
+
+/// Get the line number from a byte offset using precomputed line offsets.
+pub fn get_line_number(line_offsets: &[(usize, &str)], byte_offset: usize) -> usize {
+    match line_offsets.binary_search_by(|&(offset, _)| offset.cmp(&byte_offset)) {
+        Ok(index) => index,
+        Err(index) => index,
+    }
+}
+
+/// Extract the full line of source that `node` spans.
+pub fn get_line_content<'a>(source_code: &'a str, node: Node) -> &'a str {
+    let start = source_code[..node.start_byte()]
+        .rfind('\n')
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+    let end = source_code[node.end_byte()..]
+        .find('\n')
+        .map(|pos| node.end_byte() + pos)
+        .unwrap_or(source_code.len());
+
+    &source_code[start..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_line_content, get_line_number};
+    use tree_sitter::Parser;
+    use tree_sitter_bash as bash;
+
+    #[test]
+    fn test_get_line_number() {
+        let source = "echo first\nsecond line\nthird line\n";
+        let line_offsets: Vec<_> = source.match_indices('\n').collect();
+
+        assert_eq!(get_line_number(&line_offsets, 0), 0);
+
+        let second_line_offset = source.find("second").unwrap();
+        assert_eq!(get_line_number(&line_offsets, second_line_offset), 1);
+
+        let third_line_offset = source.find("third").unwrap();
+        assert_eq!(get_line_number(&line_offsets, third_line_offset), 2);
+    }
+
+    #[test]
+    fn test_get_line_content() {
+        let source = "echo first\nsecond line\nthird line\n";
+        let mut parser = Parser::new();
+        parser.set_language(&bash::LANGUAGE.into()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+
+        let first_cmd = tree.root_node().named_child(0).unwrap();
+        assert_eq!(get_line_content(source, first_cmd), "echo first");
+
+        let second_cmd = tree.root_node().named_child(1).unwrap();
+        assert_eq!(get_line_content(source, second_cmd), "second line");
+    }
+}

--- a/packages/binutils/crates/global/src/lib.rs
+++ b/packages/binutils/crates/global/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod debug_path_helpers;


### PR DESCRIPTION
## Summary
- add `get_line_number` and `get_line_content` helpers to library
- use helpers from `debug-path` binary
- move tests into helper module

## Testing
- `cargo test --quiet` *(fails: could not download Rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684328c984408325b04c91659928fcbf